### PR TITLE
Implemented back button on pages other than dash/settings

### DIFF
--- a/cordova/climapp/www/css/index.css
+++ b/cordova/climapp/www/css/index.css
@@ -234,7 +234,9 @@ img.small{
 }
 
 /* BEGIN navigation bar style*/
-.navigation {
+.navigation, 
+.navigation_back_settings,
+.navigation_back_dashboard {
   position: fixed;
   top: 0;
   width:100%;
@@ -253,14 +255,26 @@ img.small{
   justify-content: space-between;
 }
 
-.navigation div{
-	color: #000;
+
+.navigation div, 
+.navigation_back_settings div, 
+.navigation_back_dashboard div{
+    color: #000;
 	display: border-box;
 	margin: auto;
 }
-.navigation i{
+.navigation i {
     vertical-align: middle; /* | top | bottom */
     margin-right: 0.25em;
+}
+
+/* Making sure arrow is aligned accordingly */
+.navigation_back_settings,
+.navigation_back_dashboard {
+    display: none;
+    padding-left: 0.75em;
+    justify-content: start;
+    text-align: left;
 }
 
 /* END navigation bar style */

--- a/cordova/climapp/www/index.html
+++ b/cordova/climapp/www/index.html
@@ -47,7 +47,18 @@
                     <p><i class="fas fa-cog fa-2x" ></i> SETTINGS</p>
 					<!-- put dasjboard to the right, because i keep clicking left if i want to go to dashboard  -->
                 </div>
-			</div>
+            </div>
+            <div class="navigation_back_settings">
+                    <div data-target="settings" data-listener="navbar">
+                        <p><i class="fas fa-chevron-left fa-2x"></i></p> 
+                    </div>
+            </div>
+            <div class="navigation_back_dashboard">
+                    <div data-target="dashboard" data-listener="navbar">
+                        <p><i class="fas fa-chevron-left fa-2x"></i></p> 
+                    </div>
+            </div>
+                
 			<div class="spacer"><p>&nbsp;</p></div><!-- &nbsp; so we have same style implementation for <p> as in header -->
 			<div id="content">
 		        <!-- BK feb 6 2019: we use this div as our root, and dynamically populate it with the content we require.

--- a/cordova/climapp/www/js/index.js
+++ b/cordova/climapp/www/js/index.js
@@ -726,6 +726,8 @@ var app = {
 	updateUI: function(){
 		// context dependent filling of content
 		this.initNavbarListeners();
+		$(".navigation_back_settings").hide();
+		$(".navigation_back_dashboard").hide();
 		
 		if( this.currentPageID == "onboarding"){
 			$(".navigation").hide();
@@ -746,7 +748,8 @@ var app = {
 			this.updateInfo( this.selectedWeatherID );
 		}
 		else if( this.currentPageID == "details"){
-			$(".navigation").show();
+			$(".navigation").hide();
+			$(".navigation_back_dashboard").show();
 			var index = this.selectedWeatherID;
 			
 			let tair = this.knowledgeBase.thermalindices.phs[index].Tair.toFixed(1);
@@ -851,7 +854,8 @@ var app = {
 			$("#notification_checkbox").attr("checked", this.knowledgeBase.user_info.receivesNotifications);
 		}
 		else if( this.currentPageID == "feedback" ){
-			$(".navigation").show();
+			$(".navigation").hide();
+			$(".navigation_back_settings").show();
 			this.initFeedbackListeners();
 			// Question text
 			$("#question1").html( this.knowledgeBase.feedback.question1.text );
@@ -869,8 +873,14 @@ var app = {
 			$("input[id='3star"+this.knowledgeBase.feedback.question3.rating+"']").attr("checked", true);
 		} 
 		else if(this.currentPageID == "about") {
+			$(".navigation").hide();
+			$(".navigation_back_settings").show();
 			$("#app_version").html("App version: " + this.knowledgeBase.app_version);
 			$("#kb_version").html("Knowledgebase version: " + this.knowledgeBase.version);
+		} 
+		else if (this.currentPageID == "disclaimer") {
+			$(".navigation").hide();
+			$(".navigation_back_settings").show();
 		}
 	},
 	isDrawColdGauge: function( cold, heat, index ){

--- a/cordova/climapp/www/pages/about.html
+++ b/cordova/climapp/www/pages/about.html
@@ -5,7 +5,7 @@
 
 <div class="panel">
 	<p class="label">Image credits</p>
-	<p>Activity level icons made by <a href="http://www.freepik.com/">Freepik</a> from <a href="www.flaticon.com">www.flaticon.com</a></p>
+	<p>Activity level icons made by <a href="http://www.freepik.com/">Freepik</a> from <a href="www.flaticon.com">Flaticon</a></p>
 	<p>Weather and navigation bar icons from <a href="https://fontawesome.com/">FontAwesome</a></p>
 </div>
 


### PR DESCRIPTION
After feedback from users.

**Back button on following pages**
* `details` (reroutes to dashboard)
* `disclaimer` (reroutes to settings)
* `about` (reroutes to settings)
* `feedback` (reroutes to settings)

Is this the smartest solution? Do you have suggestions for improvement Boris?

Current solution looks like this:
![image](https://user-images.githubusercontent.com/6978512/57290777-6c9f7f00-70be-11e9-8f78-8a64d39fa75e.png)
Using the navigation layout features with some changes to the margins only for the back button.